### PR TITLE
feat(#5): .mermaid-config.json 読み込みモジュールを追加

### DIFF
--- a/src/configLoader.ts
+++ b/src/configLoader.ts
@@ -7,14 +7,17 @@
 
 import * as fs from 'node:fs';
 import * as path from 'node:path';
-import type * as vscode from 'vscode';
+import * as vscode from 'vscode';
 import { DEFAULT_MERMAID_THEME, MERMAID_CONFIG_FILENAME } from './constants';
 import type { MermaidConfig } from './types';
+
+/** 有効な Mermaid テーマ名 */
+const VALID_THEMES = ['default', 'neutral', 'dark', 'forest', 'base'] as const;
 
 /**
  * デフォルトの Mermaid 設定を返す。
  */
-function getDefaultConfig(): MermaidConfig {
+export function getDefaultConfig(): MermaidConfig {
   return {
     theme: DEFAULT_MERMAID_THEME,
     startOnLoad: false,
@@ -22,11 +25,58 @@ function getDefaultConfig(): MermaidConfig {
 }
 
 /**
+ * 読み込んだ設定オブジェクトを検証し、不正な値を除外する。
+ */
+function validateConfig(
+  config: Record<string, unknown>,
+  outputChannel: vscode.OutputChannel
+): Partial<MermaidConfig> {
+  const validated: Partial<MermaidConfig> = {};
+
+  // theme の検証
+  if (config.theme !== undefined) {
+    if (typeof config.theme === 'string' && VALID_THEMES.includes(config.theme as typeof VALID_THEMES[number])) {
+      validated.theme = config.theme as MermaidConfig['theme'];
+    } else {
+      outputChannel.appendLine(
+        `[Config] 警告: theme の値 "${String(config.theme)}" は無効です。有効な値: ${VALID_THEMES.join(', ')}`
+      );
+    }
+  }
+
+  // themeVariables の検証（オブジェクトであること）
+  if (config.themeVariables !== undefined) {
+    if (typeof config.themeVariables === 'object' && config.themeVariables !== null) {
+      validated.themeVariables = config.themeVariables as MermaidConfig['themeVariables'];
+    } else {
+      outputChannel.appendLine('[Config] 警告: themeVariables はオブジェクトである必要があります。');
+    }
+  }
+
+  // themeCSS の検証
+  if (config.themeCSS !== undefined) {
+    if (typeof config.themeCSS === 'string') {
+      validated.themeCSS = config.themeCSS;
+    }
+  }
+
+  // startOnLoad の検証
+  if (config.startOnLoad !== undefined) {
+    if (typeof config.startOnLoad === 'boolean') {
+      validated.startOnLoad = config.startOnLoad;
+    }
+  }
+
+  return validated;
+}
+
+/**
  * ワークスペースルートから .mermaid-config.json を読み込む。
  *
  * @param workspaceRoot ワークスペースのルートパス
  * @param outputChannel ログ出力用の OutputChannel
- * @returns 読み込んだ設定、または失敗時はデフォルト設定
+ * @returns 読み込んだ設定（デフォルト値とマージ済み）。
+ *          ファイル不在・読み込みエラー・パースエラー時はデフォルト設定を返す。
  */
 export function loadMermaidConfig(
   workspaceRoot: string,
@@ -45,30 +95,50 @@ export function loadMermaidConfig(
   try {
     content = fs.readFileSync(configPath, 'utf-8');
   } catch (err) {
+    const errorDetail = err instanceof Error ? err.message : String(err);
     outputChannel.appendLine(
       `[Config] ${MERMAID_CONFIG_FILENAME} の読み込みに失敗しました。デフォルト設定を使用します。`
     );
-    if (err instanceof Error) {
-      outputChannel.appendLine(`  詳細: ${err.message}`);
-    }
+    outputChannel.appendLine(`  詳細: ${errorDetail}`);
+    vscode.window.showWarningMessage(
+      `${MERMAID_CONFIG_FILENAME} の読み込みに失敗しました。詳細は Output パネルを確認してください。`
+    );
     return getDefaultConfig();
   }
 
   // JSON パース
+  let parsed: unknown;
   try {
-    const parsed = JSON.parse(content) as MermaidConfig;
-    outputChannel.appendLine(`[Config] ${MERMAID_CONFIG_FILENAME} を読み込みました。`);
-    return {
-      ...getDefaultConfig(),
-      ...parsed,
-    };
+    parsed = JSON.parse(content);
   } catch (err) {
+    const errorDetail = err instanceof Error ? err.message : String(err);
     outputChannel.appendLine(
       `[Config] ${MERMAID_CONFIG_FILENAME} のパースに失敗しました。デフォルト設定を使用します。`
     );
-    if (err instanceof Error) {
-      outputChannel.appendLine(`  詳細: ${err.message}`);
-    }
+    outputChannel.appendLine(`  詳細: ${errorDetail}`);
+    vscode.window.showWarningMessage(
+      `${MERMAID_CONFIG_FILENAME} の JSON 形式が不正です。詳細は Output パネルを確認してください。`
+    );
     return getDefaultConfig();
   }
+
+  // 型検証
+  if (typeof parsed !== 'object' || parsed === null) {
+    outputChannel.appendLine(
+      `[Config] ${MERMAID_CONFIG_FILENAME} はオブジェクトである必要があります。デフォルト設定を使用します。`
+    );
+    vscode.window.showWarningMessage(
+      `${MERMAID_CONFIG_FILENAME} の形式が不正です。オブジェクトである必要があります。`
+    );
+    return getDefaultConfig();
+  }
+
+  // 設定検証
+  const validated = validateConfig(parsed as Record<string, unknown>, outputChannel);
+  outputChannel.appendLine(`[Config] ${MERMAID_CONFIG_FILENAME} を読み込みました。`);
+
+  return {
+    ...getDefaultConfig(),
+    ...validated,
+  };
 }

--- a/src/configLoader.ts
+++ b/src/configLoader.ts
@@ -1,0 +1,74 @@
+/**
+ * Mermaid 設定読み込みモジュール
+ *
+ * docs/03-implementation/PATTERNS.md の「ワークスペース設定の優先」パターンを実装。
+ * .mermaid-config.json を読み込み、MermaidConfig を返す。
+ */
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import type * as vscode from 'vscode';
+import { DEFAULT_MERMAID_THEME, MERMAID_CONFIG_FILENAME } from './constants';
+import type { MermaidConfig } from './types';
+
+/**
+ * デフォルトの Mermaid 設定を返す。
+ */
+function getDefaultConfig(): MermaidConfig {
+  return {
+    theme: DEFAULT_MERMAID_THEME,
+    startOnLoad: false,
+  };
+}
+
+/**
+ * ワークスペースルートから .mermaid-config.json を読み込む。
+ *
+ * @param workspaceRoot ワークスペースのルートパス
+ * @param outputChannel ログ出力用の OutputChannel
+ * @returns 読み込んだ設定、または失敗時はデフォルト設定
+ */
+export function loadMermaidConfig(
+  workspaceRoot: string,
+  outputChannel: vscode.OutputChannel
+): MermaidConfig {
+  const configPath = path.join(workspaceRoot, MERMAID_CONFIG_FILENAME);
+
+  // ファイル存在チェック
+  if (!fs.existsSync(configPath)) {
+    // ファイル不在は正常ケース（デフォルト設定を使用）
+    return getDefaultConfig();
+  }
+
+  // ファイル読み込み
+  let content: string;
+  try {
+    content = fs.readFileSync(configPath, 'utf-8');
+  } catch (err) {
+    outputChannel.appendLine(
+      `[Config] ${MERMAID_CONFIG_FILENAME} の読み込みに失敗しました。デフォルト設定を使用します。`
+    );
+    if (err instanceof Error) {
+      outputChannel.appendLine(`  詳細: ${err.message}`);
+    }
+    return getDefaultConfig();
+  }
+
+  // JSON パース
+  try {
+    const parsed = JSON.parse(content) as MermaidConfig;
+    outputChannel.appendLine(`[Config] ${MERMAID_CONFIG_FILENAME} を読み込みました。`);
+    return {
+      ...getDefaultConfig(),
+      ...parsed,
+    };
+  } catch (err) {
+    outputChannel.appendLine(
+      `[Config] ${MERMAID_CONFIG_FILENAME} のパースに失敗しました。デフォルト設定を使用します。`
+    );
+    if (err instanceof Error) {
+      outputChannel.appendLine(`  詳細: ${err.message}`);
+    }
+    return getDefaultConfig();
+  }
+}

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -3,8 +3,11 @@
  * docs/03-implementation/PATTERNS.md, CONVENTIONS.md を参照。
  */
 
-/** Mermaid のデフォルトテーマ（印刷・EPUB 向け）。Issue #4 では固定で使用。 */
+/** Mermaid のデフォルトテーマ（印刷・EPUB 向け）。 */
 export const DEFAULT_MERMAID_THEME = 'neutral';
+
+/** 設定ファイル名。ワークスペースルート直下に配置。 */
+export const MERMAID_CONFIG_FILENAME = '.mermaid-config.json';
 
 /** Mermaid.js を読み込む CDN URL。Webview 用。 */
 export const MERMAID_CDN_URL =

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -6,10 +6,14 @@
 
 import * as crypto from 'node:crypto';
 import * as vscode from 'vscode';
+import { loadMermaidConfig } from './configLoader';
 import { getViewerHtml } from './viewerHtml';
 
 /** Webview 用 CSP nonce のバイト数。 */
 const NONCE_BYTES = 16;
+
+/** 拡張全体で使用する OutputChannel。activate() で初期化される。 */
+let outputChannel!: vscode.OutputChannel;
 
 /**
  * Webview 用の nonce を生成する（CSP 用）。
@@ -35,6 +39,13 @@ function openViewer(): void {
   }
   const doc = editor.document;
   const markdown = doc.getText();
+
+  // ワークスペースルートから Mermaid 設定を読み込む（#6 で Viewer に注入予定）
+  const workspaceFolder = vscode.workspace.workspaceFolders?.[0];
+  if (workspaceFolder) {
+    loadMermaidConfig(workspaceFolder.uri.fsPath, outputChannel);
+  }
+
   const panel = vscode.window.createWebviewPanel(
     'markdownMermaidViewer',
     `${doc.fileName} - Viewer`,
@@ -45,7 +56,6 @@ function openViewer(): void {
   try {
     panel.webview.html = getViewerHtml(markdown, panel.webview.cspSource, nonce);
   } catch (err) {
-    const outputChannel = vscode.window.createOutputChannel('Markdown Mermaid Viewer');
     outputChannel.appendLine(`[Viewer] ${VIEWER_OPEN_ERROR_MESSAGE}`);
     if (err instanceof Error) {
       outputChannel.appendLine(err.message);
@@ -56,10 +66,10 @@ function openViewer(): void {
 
 /**
  * 拡張がアクティベートされたときに呼ばれる。
- * Phase 1: Viewer コマンド登録。.mermaid-config.json 読み込みは #5/#6 で実装する。
+ * Phase 1: Viewer コマンド登録と設定読み込み。
  */
 export function activate(context: vscode.ExtensionContext): void {
-  const outputChannel = vscode.window.createOutputChannel('Markdown Mermaid Viewer');
+  outputChannel = vscode.window.createOutputChannel('Markdown Mermaid Viewer');
   outputChannel.appendLine('Markdown Mermaid Viewer が有効になりました。');
 
   context.subscriptions.push(outputChannel);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -6,7 +6,7 @@
 
 import * as crypto from 'node:crypto';
 import * as vscode from 'vscode';
-import { loadMermaidConfig } from './configLoader';
+import { getDefaultConfig, loadMermaidConfig } from './configLoader';
 import { getViewerHtml } from './viewerHtml';
 
 /** Webview 用 CSP nonce のバイト数。 */
@@ -40,11 +40,20 @@ function openViewer(): void {
   const doc = editor.document;
   const markdown = doc.getText();
 
-  // ワークスペースルートから Mermaid 設定を読み込む（#6 で Viewer に注入予定）
+  // ワークスペースルートから Mermaid 設定を読み込む
+  // TODO(#6): mermaidConfig を getViewerHtml に渡して Viewer に注入する
   const workspaceFolder = vscode.workspace.workspaceFolders?.[0];
-  if (workspaceFolder) {
-    loadMermaidConfig(workspaceFolder.uri.fsPath, outputChannel);
+  const mermaidConfig = workspaceFolder
+    ? loadMermaidConfig(workspaceFolder.uri.fsPath, outputChannel)
+    : getDefaultConfig();
+
+  if (!workspaceFolder) {
+    outputChannel.appendLine(
+      '[Config] ワークスペースが開かれていないため、デフォルト設定を使用します。'
+    );
   }
+
+  outputChannel.appendLine(`[Viewer] Mermaid 設定: theme=${mermaidConfig.theme}`);
 
   const panel = vscode.window.createWebviewPanel(
     'markdownMermaidViewer',
@@ -56,17 +65,17 @@ function openViewer(): void {
   try {
     panel.webview.html = getViewerHtml(markdown, panel.webview.cspSource, nonce);
   } catch (err) {
+    const errorDetail = err instanceof Error ? err.message : String(err);
     outputChannel.appendLine(`[Viewer] ${VIEWER_OPEN_ERROR_MESSAGE}`);
-    if (err instanceof Error) {
-      outputChannel.appendLine(err.message);
-    }
+    outputChannel.appendLine(`  詳細: ${errorDetail}`);
     vscode.window.showErrorMessage(VIEWER_OPEN_ERROR_MESSAGE);
   }
 }
 
 /**
  * 拡張がアクティベートされたときに呼ばれる。
- * Phase 1: Viewer コマンド登録と設定読み込み。
+ * Phase 1: OutputChannel 初期化と Viewer コマンド登録。
+ * 設定読み込みは openViewer() 内で Viewer を開くたびに実行される。
  */
 export function activate(context: vscode.ExtensionContext): void {
   outputChannel = vscode.window.createOutputChannel('Markdown Mermaid Viewer');

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,7 +10,7 @@ export type MermaidTheme = 'default' | 'neutral' | 'dark' | 'forest' | 'base';
 
 /**
  * base テーマ使用時のカスタムテーマ変数。
- * theme === 'base' のときのみ有効（Mermaid 仕様）。
+ * theme === 'base' のときのみ有効。他のテーマでは無視される（Mermaid 仕様）。
  */
 export interface MermaidThemeVariables {
   primaryColor?: string;
@@ -34,6 +34,6 @@ export interface MermaidConfig {
   themeVariables?: MermaidThemeVariables;
   themeCSS?: string;
   startOnLoad?: boolean;
-  securityLevel?: 'strict' | 'loose' | 'antitamper' | 'sandbox';
-  logLevel?: 'fatal' | 'error' | 'warn' | 'info' | 'debug' | 'trace';
+  securityLevel?: 'strict' | 'loose' | 'antiscript' | 'sandbox';
+  logLevel?: 'fatal' | 'error' | 'warn' | 'info' | 'debug' | 'trace' | 0 | 1 | 2 | 3 | 4 | 5;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,39 @@
+/**
+ * Mermaid 設定スキーマ（Domain 層）
+ *
+ * docs/02-design/ARCHITECTURE.md の Domain 層に対応。
+ * Mermaid 公式の設定仕様に準拠。
+ */
+
+/** Mermaid の組み込みテーマ名 */
+export type MermaidTheme = 'default' | 'neutral' | 'dark' | 'forest' | 'base';
+
+/**
+ * base テーマ使用時のカスタムテーマ変数。
+ * theme === 'base' のときのみ有効（Mermaid 仕様）。
+ */
+export interface MermaidThemeVariables {
+  primaryColor?: string;
+  primaryTextColor?: string;
+  primaryBorderColor?: string;
+  lineColor?: string;
+  secondaryColor?: string;
+  tertiaryColor?: string;
+  fontFamily?: string;
+  fontSize?: string;
+  /** その他のカスタム変数を許容 */
+  [key: string]: string | undefined;
+}
+
+/**
+ * .mermaid-config.json の設定オブジェクト。
+ * Mermaid.initialize() に渡す設定と対応。
+ */
+export interface MermaidConfig {
+  theme?: MermaidTheme;
+  themeVariables?: MermaidThemeVariables;
+  themeCSS?: string;
+  startOnLoad?: boolean;
+  securityLevel?: 'strict' | 'loose' | 'antitamper' | 'sandbox';
+  logLevel?: 'fatal' | 'error' | 'warn' | 'info' | 'debug' | 'trace';
+}


### PR DESCRIPTION
## 概要
Closes #5

ワークスペースルートの `.mermaid-config.json` を読み込み、Mermaid 設定オブジェクトを返すモジュールを実装しました。

## 変更内容

### 新規ファイル
- **src/types.ts**: Domain 層の型定義
  - `MermaidTheme`: 組み込みテーマ名の union 型
  - `MermaidThemeVariables`: base テーマ用のカスタム変数
  - `MermaidConfig`: .mermaid-config.json の設定オブジェクト型

- **src/configLoader.ts**: 設定読み込みモジュール
  - `loadMermaidConfig()`: ワークスペースから設定を読み込み
  - ファイル不在時はデフォルト設定を返す
  - JSON パースエラー時は OutputChannel に警告 + デフォルトにフォールバック

### 変更ファイル
- **src/constants.ts**: `MERMAID_CONFIG_FILENAME` 定数を追加
- **src/extension.ts**: `openViewer()` 内で `loadMermaidConfig()` を呼び出し

## 受け入れ条件（Issue #5 より）
- [x] ルートに `.mermaid-config.json` があるとき → その内容が返る
- [x] ファイルがないとき → デフォルトが返る
- [x] JSON が壊れているとき → デフォルトが返り、警告がログに出る

## テスト計画
- [x] `npm run compile` でビルド成功
- [ ] VS Code でデバッグ実行（F5）し、OutputChannel に設定読み込みログが出ることを確認
- [ ] #6 完了後、Viewer に設定が反映されることを確認

## 関連
- 親 Issue: #3 (Phase 1 MVP)
- 次の Issue: #6 (Viewer へ設定を注入)

🤖 Generated with [Claude Code](https://claude.com/claude-code)