### PR TITLE
feat(#7): テーマ・themeVariables 対応（base 時のみ有効）

### DIFF
--- a/src/configLoader.ts
+++ b/src/configLoader.ts
@@ -52,10 +52,16 @@ function validateConfig(
     }
   }
 
-  // themeVariables の検証（オブジェクトであること）
+  // themeVariables の検証（オブジェクトであること + base テーマ時のみ有効）
   if (config.themeVariables !== undefined) {
     if (typeof config.themeVariables === 'object' && config.themeVariables !== null) {
       validated.themeVariables = config.themeVariables as MermaidConfig['themeVariables'];
+      // base テーマ以外で themeVariables が指定されている場合は警告
+      if (config.theme !== 'base') {
+        outputChannel.appendLine(
+          '[Config] 注意: themeVariables は theme: "base" のときのみ有効です。現在のテーマでは無視されます。'
+        );
+      }
     } else {
       outputChannel.appendLine('[Config] 警告: themeVariables はオブジェクトである必要があります。');
     }

--- a/src/viewerHtml.ts
+++ b/src/viewerHtml.ts
@@ -58,12 +58,19 @@ function splitMarkdownAndMermaid(markdown: string): Array<{ kind: 'markdown' | '
 
 /**
  * MermaidConfig を JSON 文字列に変換する。
- * 循環参照や BigInt などで失敗した場合はエラーをスローする。
+ * - theme !== 'base' の場合、themeVariables は除外される（Mermaid 仕様）
+ * - 循環参照や BigInt などで失敗した場合はエラーをスローする
  */
 function stringifyMermaidConfig(config: MermaidConfig): string {
-  const configWithDefaults = { ...config, startOnLoad: false };
+  // base テーマ以外では themeVariables を除外（Mermaid の仕様に準拠）
+  const { themeVariables, ...restConfig } = config;
+  const effectiveConfig: MermaidConfig =
+    config.theme === 'base'
+      ? { ...config, startOnLoad: false }
+      : { ...restConfig, startOnLoad: false };
+
   try {
-    return JSON.stringify(configWithDefaults);
+    return JSON.stringify(effectiveConfig);
   } catch (err) {
     const detail = err instanceof Error ? err.message : String(err);
     throw new Error(


### PR DESCRIPTION
## 概要
Closes #7

Mermaid の仕様に従い、`theme === 'base'` のときのみ `themeVariables` を有効にしました。

## 変更内容

### src/viewerHtml.ts
- `stringifyMermaidConfig()` で theme !== 'base' の場合、themeVariables を除外
- Destructuring で不要なプロパティを除外するパターンを使用

### src/configLoader.ts
- base 以外のテーマで themeVariables が指定された場合に警告を OutputChannel に出力
- ユーザーに「無視される」ことを明示的に伝える

## 受け入れ条件（Issue #7 より）
- [x] theme: base かつ themeVariables を書くと、色・フォント等が反映される
- [x] 他テーマのとき themeVariables を書いても無視される（警告あり）

## テスト計画
- [x] `npm run compile` でビルド成功
- [ ] VS Code でデバッグ実行（F5）
- [ ] `.mermaid-config.json` で theme: "base" + themeVariables を設定し、反映されることを確認
- [ ] theme: "neutral" + themeVariables を設定し、警告が出て themeVariables が無視されることを確認

## 関連
- 親 Issue: #3 (Phase 1 MVP)
- 次の Issue: #8 (README 整備)

🤖 Generated with [Claude Code](https://claude.com/claude-code)