### PR TITLE
feat: #18 #17 #16 #15 Phase 2 EPUB/PDF エクスポート機能を実装

### DIFF
--- a/.mermaid-config.json
+++ b/.mermaid-config.json
@@ -1,0 +1,13 @@
+{
+  "theme": "neutral",
+  "export": {
+    "dpi": 300,
+    "width": 800,
+    "epub": {
+      "format": "png"
+    },
+    "pdf": {
+      "format": "svg"
+    }
+  }
+}

--- a/README.md
+++ b/README.md
@@ -12,7 +12,10 @@ VS Code 拡張「**Markdown Mermaid Viewer**」です。Markdown 内の Mermaid 
 - ✅ Markdown 内の Mermaid ブロック（**\`\`\`mermaid**）をプレビュー
 - ✅ `.mermaid-config.json` でテーマやスタイルをカスタマイズ
 - ✅ 印刷・電子書籍向けの `neutral` テーマをデフォルト採用
-- 🚧 EPUB/PDF エクスポート（Phase 2 で対応予定）
+- ✅ **EPUB/PDF エクスポート**（mermaid-filter + Pandoc）
+  - Mermaid 図を画像に自動変換
+  - 解像度・幅・形式を細かく設定可能
+  - Kindle/電子書籍向けに最適化
 
 ## インストール
 
@@ -33,6 +36,43 @@ npm run compile
 
 # VS Code でデバッグ実行（F5）
 ```
+
+## エクスポート機能の依存関係
+
+EPUB/PDF エクスポート機能を使用するには、以下のツールが必要です。
+
+### 必須
+
+- **[mermaid-filter](https://github.com/raghur/mermaid-filter)**: Mermaid ブロックを画像に変換
+- **[Pandoc](https://pandoc.org/)**: Markdown → EPUB/PDF 変換
+
+```bash
+# mermaid-filter のインストール
+npm install -g mermaid-filter
+
+# Pandoc のインストール（macOS）
+brew install pandoc
+
+# Pandoc のインストール（その他の OS）
+# https://pandoc.org/installing.html を参照
+```
+
+### PDF エクスポート用（オプション）
+
+PDF エクスポートには、追加で以下が必要です：
+
+- **pdflatex**: PDF 生成エンジン（[MacTeX](https://tug.org/mactex/) に含まれる）
+- **rsvg-convert**: SVG → PDF 変換用（SVG 形式を使用する場合のみ）
+
+```bash
+# pdflatex のインストール（macOS）
+brew install --cask mactex
+
+# rsvg-convert のインストール（macOS）
+brew install librsvg
+```
+
+> **注意**: pdflatex は大きなパッケージ（数 GB）です。EPUB エクスポートのみを使用する場合は不要です。
 
 ## 使い方
 
@@ -66,6 +106,17 @@ graph TD
     D --> E
 ```
 ~~~
+
+### 4. EPUB/PDF にエクスポート（Phase 2）
+
+コマンドパレット（`Ctrl+Shift+P` / `Cmd+Shift+P`）から以下のコマンドを実行します：
+
+- **「EPUB にエクスポート」**: EPUB 形式でエクスポート
+- **「PDF にエクスポート」**: PDF 形式でエクスポート
+
+または、エディタ右上のボタンからもエクスポートできます。
+
+Mermaid 図は自動的に画像（PNG/SVG）に変換され、ドキュメントに埋め込まれます。
 
 ## 設定（.mermaid-config.json）
 
@@ -120,12 +171,43 @@ graph TD
 
 > **セキュリティ**: `themeCSS` で `url()`, `expression()`, `javascript:`, `@import` は使用できません。
 
+### エクスポート設定例（Phase 2）
+
+`export` フィールドで、EPUB/PDF エクスポート時の画像設定をカスタマイズできます。
+
+```json
+{
+  "theme": "neutral",
+  "export": {
+    "dpi": 300,
+    "width": 800,
+    "epub": {
+      "format": "png"
+    },
+    "pdf": {
+      "format": "svg"
+    }
+  }
+}
+```
+
+| プロパティ | 説明 | デフォルト値 | 範囲 |
+|-----------|------|------------|------|
+| `dpi` | 解像度（DPI） | 300 | 72-600 |
+| `width` | 図の最大幅（px） | 800 | 400-2000 |
+| `epub.format` | EPUB 用画像形式 | `png` | `png` / `svg` |
+| `pdf.format` | PDF 用画像形式 | `svg` | `png` / `svg` |
+
+**推奨設定:**
+- **Kindle/電子書籍**: `dpi: 300`, `epub.format: "png"`（互換性重視）
+- **印刷/高品質 PDF**: `dpi: 300-600`, `pdf.format: "svg"`（ベクター形式で高品質）
+
 ## ロードマップ
 
 | Phase | 内容 | 状態 |
 |-------|------|------|
 | **Phase 1** | Mermaid プレビュー + .mermaid-config.json 対応 | ✅ 完了 |
-| **Phase 2** | EPUB/PDF エクスポート（mermaid-filter + Pandoc） | 🚧 予定 |
+| **Phase 2** | EPUB/PDF エクスポート（mermaid-filter + Pandoc） | ✅ 完了 |
 | **Phase 3** | パフォーマンス最適化、KDP 向け補助機能 | 📋 計画中 |
 
 ## 開発者向け情報

--- a/package.json
+++ b/package.json
@@ -16,13 +16,25 @@
   "main": "./out/extension.js",
   "activationEvents": [
     "onStartupFinished",
-    "onCommand:markdownMermaidViewer.openViewer"
+    "onCommand:markdownMermaidViewer.openViewer",
+    "onCommand:markdownMermaidViewer.exportToEpub",
+    "onCommand:markdownMermaidViewer.exportToPdf"
   ],
   "contributes": {
     "commands": [
       {
         "command": "markdownMermaidViewer.openViewer",
         "title": "Viewer を開く"
+      },
+      {
+        "command": "markdownMermaidViewer.exportToEpub",
+        "title": "EPUB にエクスポート",
+        "icon": "$(book)"
+      },
+      {
+        "command": "markdownMermaidViewer.exportToPdf",
+        "title": "PDF にエクスポート",
+        "icon": "$(file-pdf)"
       }
     ],
     "menus": {
@@ -31,6 +43,16 @@
           "command": "markdownMermaidViewer.openViewer",
           "when": "editorLangId == markdown",
           "group": "navigation"
+        },
+        {
+          "command": "markdownMermaidViewer.exportToEpub",
+          "when": "editorLangId == markdown",
+          "group": "1_export"
+        },
+        {
+          "command": "markdownMermaidViewer.exportToPdf",
+          "when": "editorLangId == markdown",
+          "group": "1_export"
         }
       ]
     },

--- a/src/configLoader.ts
+++ b/src/configLoader.ts
@@ -56,6 +56,28 @@ export function getDefaultExportOptions(): ExportOptions {
 }
 
 /**
+ * フォーマット設定（epub/pdf.format）を検証するヘルパー関数
+ */
+function validateFormat(
+  formatOpts: unknown,
+  target: 'epub' | 'pdf',
+  outputChannel: vscode.OutputChannel
+): { readonly format: 'png' | 'svg' } | undefined {
+  if (formatOpts !== undefined && typeof formatOpts === 'object' && formatOpts !== null) {
+    const formatContainer = formatOpts as Record<string, unknown>;
+    if (formatContainer.format !== undefined) {
+      if (formatContainer.format === 'png' || formatContainer.format === 'svg') {
+        return { format: formatContainer.format };
+      }
+      outputChannel.appendLine(
+        `[Config] 警告: export.${target}.format の値 "${String(formatContainer.format)}" は無効です。有効な値: png, svg`
+      );
+    }
+  }
+  return undefined;
+}
+
+/**
  * export フィールドの値を検証し、有効なフィールドのみを返す。
  * 無効な値（範囲外・型不一致）は警告を出力し、デフォルト値にフォールバックする。
  */
@@ -94,31 +116,15 @@ function validateExportOptions(
   }
 
   // epub.format の検証
-  if (opts.epub !== undefined && typeof opts.epub === 'object' && opts.epub !== null) {
-    const epub = opts.epub as Record<string, unknown>;
-    if (epub.format !== undefined) {
-      if (epub.format === 'png' || epub.format === 'svg') {
-        validated.epub = { format: epub.format };
-      } else {
-        outputChannel.appendLine(
-          `[Config] 警告: export.epub.format の値 "${String(epub.format)}" は無効です。有効な値: png, svg`
-        );
-      }
-    }
+  const epubFormat = validateFormat(opts.epub, 'epub', outputChannel);
+  if (epubFormat) {
+    validated.epub = epubFormat;
   }
 
   // pdf.format の検証
-  if (opts.pdf !== undefined && typeof opts.pdf === 'object' && opts.pdf !== null) {
-    const pdf = opts.pdf as Record<string, unknown>;
-    if (pdf.format !== undefined) {
-      if (pdf.format === 'png' || pdf.format === 'svg') {
-        validated.pdf = { format: pdf.format };
-      } else {
-        outputChannel.appendLine(
-          `[Config] 警告: export.pdf.format の値 "${String(pdf.format)}" は無効です。有効な値: png, svg`
-        );
-      }
-    }
+  const pdfFormat = validateFormat(opts.pdf, 'pdf', outputChannel);
+  if (pdfFormat) {
+    validated.pdf = pdfFormat;
   }
 
   return validated as Partial<ExportOptions>;

--- a/src/configLoader.ts
+++ b/src/configLoader.ts
@@ -44,7 +44,7 @@ export function getDefaultConfig(): MermaidConfig {
 }
 
 /**
- * デフォルトの ExportOptions を返す（Phase 2）
+ * エクスポート設定のデフォルト値を返す。
  */
 export function getDefaultExportOptions(): ExportOptions {
   return {
@@ -56,7 +56,8 @@ export function getDefaultExportOptions(): ExportOptions {
 }
 
 /**
- * export フィールドを検証し、範囲外の値を補正する（Phase 2）
+ * export フィールドの値を検証し、有効なフィールドのみを返す。
+ * 無効な値（範囲外・型不一致）は警告を出力し、デフォルト値にフォールバックする。
  */
 function validateExportOptions(
   exportOpts: unknown,
@@ -67,7 +68,8 @@ function validateExportOptions(
   }
 
   const opts = exportOpts as Record<string, unknown>;
-  const validated: Partial<ExportOptions> = {};
+  // readonly プロパティを持つ ExportOptions を構築するため、一時的なオブジェクトとして扱う
+  const validated: Record<string, unknown> = {};
 
   // DPI の検証
   if (opts.dpi !== undefined) {
@@ -119,7 +121,7 @@ function validateExportOptions(
     }
   }
 
-  return validated;
+  return validated as Partial<ExportOptions>;
 }
 
 /**
@@ -182,7 +184,7 @@ function validateConfig(
     }
   }
 
-  // export フィールドの検証（Phase 2）
+  // export フィールドの検証
   if (config.export !== undefined) {
     const exportOpts = validateExportOptions(config.export, outputChannel);
     if (Object.keys(exportOpts).length > 0) {

--- a/src/configLoader.ts
+++ b/src/configLoader.ts
@@ -8,8 +8,19 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import * as vscode from 'vscode';
-import { DEFAULT_MERMAID_THEME, MERMAID_CONFIG_FILENAME } from './constants';
-import type { MermaidConfig } from './types';
+import {
+  DEFAULT_EPUB_FORMAT,
+  DEFAULT_EXPORT_DPI,
+  DEFAULT_EXPORT_WIDTH,
+  DEFAULT_MERMAID_THEME,
+  DEFAULT_PDF_FORMAT,
+  MAX_EXPORT_DPI,
+  MAX_EXPORT_WIDTH,
+  MERMAID_CONFIG_FILENAME,
+  MIN_EXPORT_DPI,
+  MIN_EXPORT_WIDTH,
+} from './constants';
+import type { ExportOptions, MermaidConfig } from './types';
 
 /** 有効な Mermaid テーマ名 */
 const VALID_THEMES = ['default', 'neutral', 'dark', 'forest', 'base'] as const;
@@ -30,6 +41,85 @@ export function getDefaultConfig(): MermaidConfig {
     theme: DEFAULT_MERMAID_THEME,
     startOnLoad: false,
   };
+}
+
+/**
+ * デフォルトの ExportOptions を返す（Phase 2）
+ */
+export function getDefaultExportOptions(): ExportOptions {
+  return {
+    dpi: DEFAULT_EXPORT_DPI,
+    width: DEFAULT_EXPORT_WIDTH,
+    epub: { format: DEFAULT_EPUB_FORMAT },
+    pdf: { format: DEFAULT_PDF_FORMAT },
+  };
+}
+
+/**
+ * export フィールドを検証し、範囲外の値を補正する（Phase 2）
+ */
+function validateExportOptions(
+  exportOpts: unknown,
+  outputChannel: vscode.OutputChannel
+): Partial<ExportOptions> {
+  if (typeof exportOpts !== 'object' || exportOpts === null) {
+    return {};
+  }
+
+  const opts = exportOpts as Record<string, unknown>;
+  const validated: Partial<ExportOptions> = {};
+
+  // DPI の検証
+  if (opts.dpi !== undefined) {
+    if (typeof opts.dpi === 'number' && opts.dpi >= MIN_EXPORT_DPI && opts.dpi <= MAX_EXPORT_DPI) {
+      validated.dpi = opts.dpi;
+    } else {
+      outputChannel.appendLine(
+        `[Config] 警告: export.dpi の値 "${String(opts.dpi)}" は無効です。有効範囲: ${MIN_EXPORT_DPI}-${MAX_EXPORT_DPI}`
+      );
+    }
+  }
+
+  // width の検証
+  if (opts.width !== undefined) {
+    if (typeof opts.width === 'number' && opts.width >= MIN_EXPORT_WIDTH && opts.width <= MAX_EXPORT_WIDTH) {
+      validated.width = opts.width;
+    } else {
+      outputChannel.appendLine(
+        `[Config] 警告: export.width の値 "${String(opts.width)}" は無効です。有効範囲: ${MIN_EXPORT_WIDTH}-${MAX_EXPORT_WIDTH}`
+      );
+    }
+  }
+
+  // epub.format の検証
+  if (opts.epub !== undefined && typeof opts.epub === 'object' && opts.epub !== null) {
+    const epub = opts.epub as Record<string, unknown>;
+    if (epub.format !== undefined) {
+      if (epub.format === 'png' || epub.format === 'svg') {
+        validated.epub = { format: epub.format };
+      } else {
+        outputChannel.appendLine(
+          `[Config] 警告: export.epub.format の値 "${String(epub.format)}" は無効です。有効な値: png, svg`
+        );
+      }
+    }
+  }
+
+  // pdf.format の検証
+  if (opts.pdf !== undefined && typeof opts.pdf === 'object' && opts.pdf !== null) {
+    const pdf = opts.pdf as Record<string, unknown>;
+    if (pdf.format !== undefined) {
+      if (pdf.format === 'png' || pdf.format === 'svg') {
+        validated.pdf = { format: pdf.format };
+      } else {
+        outputChannel.appendLine(
+          `[Config] 警告: export.pdf.format の値 "${String(pdf.format)}" は無効です。有効な値: png, svg`
+        );
+      }
+    }
+  }
+
+  return validated;
 }
 
 /**
@@ -89,6 +179,14 @@ function validateConfig(
   if (config.startOnLoad !== undefined) {
     if (typeof config.startOnLoad === 'boolean') {
       validated.startOnLoad = config.startOnLoad;
+    }
+  }
+
+  // export フィールドの検証（Phase 2）
+  if (config.export !== undefined) {
+    const exportOpts = validateExportOptions(config.export, outputChannel);
+    if (Object.keys(exportOpts).length > 0) {
+      validated.export = exportOpts;
     }
   }
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -15,3 +15,32 @@ export const MERMAID_CDN_URL =
 
 /** Viewer 内で Mermaid 描画に失敗したときに表示するメッセージ。 */
 export const VIEWER_RENDER_ERROR_MESSAGE = '図の描画に失敗しました。';
+
+// ==================== Phase 2: エクスポート関連定数 ====================
+
+/** エクスポート時のデフォルト解像度（DPI）。印刷・電子書籍向けに最適化。範囲: 72-600 */
+export const DEFAULT_EXPORT_DPI = 300;
+
+/** エクスポート時の図のデフォルト幅（px）。範囲: 400-2000 */
+export const DEFAULT_EXPORT_WIDTH = 800;
+
+/** DPI の有効範囲（最小値）。 */
+export const MIN_EXPORT_DPI = 72;
+
+/** DPI の有効範囲（最大値）。 */
+export const MAX_EXPORT_DPI = 600;
+
+/** 図の幅の有効範囲（最小値、px）。 */
+export const MIN_EXPORT_WIDTH = 400;
+
+/** 図の幅の有効範囲（最大値、px）。 */
+export const MAX_EXPORT_WIDTH = 2000;
+
+/** EPUB エクスポート時のデフォルト画像形式。Kindle 互換性を優先。 */
+export const DEFAULT_EPUB_FORMAT = 'png';
+
+/** PDF エクスポート時のデフォルト画像形式。ベクター形式で高品質。 */
+export const DEFAULT_PDF_FORMAT = 'svg';
+
+/** エクスポートコマンド実行時のタイムアウト（ms）。Pandoc 実行を想定。範囲: 30000-300000 */
+export const EXPORT_COMMAND_TIMEOUT_MS = 120000; // 120秒

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -37,10 +37,10 @@ export const MIN_EXPORT_WIDTH = 400;
 export const MAX_EXPORT_WIDTH = 2000;
 
 /** EPUB エクスポート時のデフォルト画像形式。Kindle 互換性を優先。 */
-export const DEFAULT_EPUB_FORMAT = 'png';
+export const DEFAULT_EPUB_FORMAT = 'png' as const;
 
 /** PDF エクスポート時のデフォルト画像形式。ベクター形式で高品質。 */
-export const DEFAULT_PDF_FORMAT = 'svg';
+export const DEFAULT_PDF_FORMAT = 'svg' as const;
 
 /** エクスポートコマンド実行時のタイムアウト（ms）。Pandoc 実行を想定。範囲: 30000-300000 */
 export const EXPORT_COMMAND_TIMEOUT_MS = 120000; // 120秒

--- a/src/exportFormatResolver.ts
+++ b/src/exportFormatResolver.ts
@@ -1,0 +1,62 @@
+/**
+ * エクスポート形式解決モジュール
+ * Phase 2: ターゲット（EPUB/PDF）に応じた画像形式・解像度・幅を決定する。
+ *
+ * docs/03-implementation/PATTERNS.md および CONVENTIONS.md を参照。
+ */
+import {
+  DEFAULT_EPUB_FORMAT,
+  DEFAULT_EXPORT_DPI,
+  DEFAULT_EXPORT_WIDTH,
+  DEFAULT_PDF_FORMAT,
+} from './constants';
+import type { ExportOptions } from './types';
+
+export type ExportTarget = 'epub' | 'pdf';
+export type ImageFormat = 'png' | 'svg';
+
+/**
+ * エクスポートターゲットに応じた画像形式を解決する
+ */
+export function resolveImageFormat(
+  target: ExportTarget,
+  exportOptions?: ExportOptions
+): ImageFormat {
+  if (!exportOptions) {
+    return target === 'epub' ? DEFAULT_EPUB_FORMAT : DEFAULT_PDF_FORMAT;
+  }
+
+  if (target === 'epub') {
+    return exportOptions.epub?.format ?? DEFAULT_EPUB_FORMAT;
+  } else {
+    return exportOptions.pdf?.format ?? DEFAULT_PDF_FORMAT;
+  }
+}
+
+/**
+ * 解像度（DPI）を解決する
+ */
+export function resolveDpi(exportOptions?: ExportOptions): number {
+  return exportOptions?.dpi ?? DEFAULT_EXPORT_DPI;
+}
+
+/**
+ * 図の幅（px）を解決する
+ */
+export function resolveWidth(exportOptions?: ExportOptions): number {
+  return exportOptions?.width ?? DEFAULT_EXPORT_WIDTH;
+}
+
+/**
+ * mermaid-filter 用の環境変数を生成する
+ */
+export function buildMermaidFilterEnv(
+  format: ImageFormat,
+  width: number
+): NodeJS.ProcessEnv {
+  return {
+    ...process.env,
+    MERMAID_FILTER_FORMAT: format,
+    MERMAID_FILTER_WIDTH: String(width),
+  };
+}

--- a/src/exportFormatResolver.ts
+++ b/src/exportFormatResolver.ts
@@ -1,6 +1,6 @@
 /**
  * エクスポート形式解決モジュール
- * Phase 2: ターゲット（EPUB/PDF）に応じた画像形式・解像度・幅を決定する。
+ * ターゲット（EPUB/PDF）に応じた画像形式・解像度・幅を決定する。
  *
  * docs/03-implementation/PATTERNS.md および CONVENTIONS.md を参照。
  */
@@ -16,7 +16,8 @@ export type ExportTarget = 'epub' | 'pdf';
 export type ImageFormat = 'png' | 'svg';
 
 /**
- * エクスポートターゲットに応じた画像形式を解決する
+ * エクスポートターゲット（EPUB/PDF）に応じた画像形式を取得する。
+ * 設定が未指定の場合、EPUB は PNG（Kindle 互換性）、PDF は SVG（高品質）を返す。
  */
 export function resolveImageFormat(
   target: ExportTarget,
@@ -34,14 +35,16 @@ export function resolveImageFormat(
 }
 
 /**
- * 解像度（DPI）を解決する
+ * エクスポート用の解像度（DPI）を取得する。
+ * 設定が未指定の場合はデフォルト値（300 DPI）を返す。
  */
 export function resolveDpi(exportOptions?: ExportOptions): number {
   return exportOptions?.dpi ?? DEFAULT_EXPORT_DPI;
 }
 
 /**
- * 図の幅（px）を解決する
+ * エクスポート用の図の最大幅（px）を取得する。
+ * 設定が未指定の場合はデフォルト値（800px）を返す。
  */
 export function resolveWidth(exportOptions?: ExportOptions): number {
   return exportOptions?.width ?? DEFAULT_EXPORT_WIDTH;

--- a/src/exportPipeline.ts
+++ b/src/exportPipeline.ts
@@ -1,0 +1,135 @@
+/**
+ * エクスポートパイプライン
+ * Phase 2: Pandoc + mermaid-filter による EPUB/PDF エクスポート実行。
+ *
+ * docs/02-design/ARCHITECTURE.md の Infrastructure 層に対応。
+ */
+import * as childProcess from 'node:child_process';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { promisify } from 'node:util';
+import * as vscode from 'vscode';
+import { EXPORT_COMMAND_TIMEOUT_MS } from './constants';
+import type { ExportTarget, ImageFormat } from './exportFormatResolver';
+import {
+  buildMermaidFilterEnv,
+  resolveDpi,
+  resolveImageFormat,
+  resolveWidth,
+} from './exportFormatResolver';
+import type { MermaidConfig } from './types';
+
+const execFile = promisify(childProcess.execFile);
+
+export interface ExportPipelineOptions {
+  inputPath: string;
+  outputPath: string;
+  target: ExportTarget;
+  mermaidConfig: MermaidConfig;
+  workingDirectory: string;
+}
+
+/**
+ * Pandoc を実行して Markdown を EPUB/PDF に変換する
+ */
+async function runPandoc(
+  options: ExportPipelineOptions,
+  format: ImageFormat,
+  dpi: number,
+  outputChannel: vscode.OutputChannel
+): Promise<void> {
+  const { inputPath, outputPath, workingDirectory } = options;
+
+  const args = [
+    inputPath,
+    '-F', 'mermaid-filter',
+    '-o', outputPath,
+    '--dpi', String(dpi),
+  ];
+
+  outputChannel.appendLine(`[Export] Pandoc コマンド: pandoc ${args.join(' ')}`);
+  outputChannel.appendLine(`[Export] 作業ディレクトリ: ${workingDirectory}`);
+
+  const width = resolveWidth(options.mermaidConfig.export);
+  const env = buildMermaidFilterEnv(format, width);
+
+  try {
+    const { stdout, stderr } = await execFile('pandoc', args, {
+      cwd: workingDirectory,
+      env,
+      timeout: EXPORT_COMMAND_TIMEOUT_MS,
+    });
+
+    if (stdout) {
+      outputChannel.appendLine(`[Export] Pandoc stdout: ${stdout}`);
+    }
+    if (stderr) {
+      outputChannel.appendLine(`[Export] Pandoc stderr: ${stderr}`);
+    }
+
+    outputChannel.appendLine(`[Export] エクスポート成功: ${outputPath}`);
+  } catch (err) {
+    const errorDetail = err instanceof Error ? err.message : String(err);
+    const stderr = (err as { stderr?: string }).stderr;
+
+    outputChannel.appendLine(`[Export] Pandoc 実行に失敗しました。`);
+    outputChannel.appendLine(`  詳細: ${errorDetail}`);
+    if (stderr) {
+      outputChannel.appendLine(`  stderr: ${stderr}`);
+    }
+
+    throw new Error(`Pandoc 実行に失敗しました: ${errorDetail}`);
+  }
+}
+
+/**
+ * .mermaid-config.json を作業ディレクトリに書き出す
+ */
+async function writeMermaidConfig(
+  workingDirectory: string,
+  mermaidConfig: MermaidConfig,
+  outputChannel: vscode.OutputChannel
+): Promise<void> {
+  const configPath = path.join(workingDirectory, '.mermaid-config.json');
+
+  const cliConfig = {
+    theme: mermaidConfig.theme,
+    themeVariables: mermaidConfig.theme === 'base' ? mermaidConfig.themeVariables : undefined,
+    themeCSS: mermaidConfig.themeCSS,
+  };
+
+  try {
+    await fs.promises.writeFile(
+      configPath,
+      JSON.stringify(cliConfig, null, 2),
+      'utf-8'
+    );
+    outputChannel.appendLine(`[Export] .mermaid-config.json を作業ディレクトリに書き出しました: ${configPath}`);
+  } catch (err) {
+    const errorDetail = err instanceof Error ? err.message : String(err);
+    outputChannel.appendLine(`[Export] 警告: .mermaid-config.json の書き出しに失敗しました。`);
+    outputChannel.appendLine(`  詳細: ${errorDetail}`);
+  }
+}
+
+/**
+ * エクスポートパイプラインを実行する
+ */
+export async function runExportPipeline(
+  options: ExportPipelineOptions,
+  outputChannel: vscode.OutputChannel
+): Promise<void> {
+  const { target, mermaidConfig, workingDirectory } = options;
+
+  outputChannel.appendLine(`[Export] ${target.toUpperCase()} エクスポートを開始します...`);
+
+  const format = resolveImageFormat(target, mermaidConfig.export);
+  const dpi = resolveDpi(mermaidConfig.export);
+
+  outputChannel.appendLine(`[Export] 画像形式: ${format}, DPI: ${dpi}`);
+
+  await writeMermaidConfig(workingDirectory, mermaidConfig, outputChannel);
+  await runPandoc(options, format, dpi, outputChannel);
+
+  outputChannel.appendLine(`[Export] ${target.toUpperCase()} エクスポートが完了しました。`);
+}

--- a/src/exportPipeline.ts
+++ b/src/exportPipeline.ts
@@ -1,6 +1,6 @@
 /**
  * エクスポートパイプライン
- * Phase 2: Pandoc + mermaid-filter による EPUB/PDF エクスポート実行。
+ * Pandoc + mermaid-filter による EPUB/PDF エクスポート実行。
  *
  * docs/02-design/ARCHITECTURE.md の Infrastructure 層に対応。
  */
@@ -70,20 +70,63 @@ async function runPandoc(
     outputChannel.appendLine(`[Export] エクスポート成功: ${outputPath}`);
   } catch (err) {
     const errorDetail = err instanceof Error ? err.message : String(err);
+    const errorCode = (err as { code?: string }).code;
     const stderr = (err as { stderr?: string }).stderr;
 
+    // ログに詳細を出力
     outputChannel.appendLine(`[Export] Pandoc 実行に失敗しました。`);
+    outputChannel.appendLine(`  エラーコード: ${errorCode || 'unknown'}`);
     outputChannel.appendLine(`  詳細: ${errorDetail}`);
     if (stderr) {
       outputChannel.appendLine(`  stderr: ${stderr}`);
     }
 
-    throw new Error(`Pandoc 実行に失敗しました: ${errorDetail}`);
+    // エラーコード別に具体的なメッセージを生成
+    if (errorCode === 'ETIMEDOUT') {
+      throw new Error(
+        `Pandoc 実行がタイムアウトしました（${EXPORT_COMMAND_TIMEOUT_MS / 1000}秒）。\n` +
+        `大きなファイルや複雑な図が含まれている可能性があります。\n` +
+        `詳細: ${errorDetail}`
+      );
+    }
+
+    if (errorCode === 'ENOENT') {
+      throw new Error(
+        `Pandoc または mermaid-filter が見つかりません。\n` +
+        `ツールチェックは成功しましたが、実行時に見つかりませんでした。\n` +
+        `詳細: ${errorDetail}`
+      );
+    }
+
+    if (errorCode === 'EACCES') {
+      throw new Error(
+        `ファイルのアクセス権限エラーが発生しました。\n` +
+        `出力先ディレクトリへの書き込み権限を確認してください。\n` +
+        `詳細: ${errorDetail}`
+      );
+    }
+
+    // stderr から mermaid-filter 特有のエラーを検出
+    if (stderr && stderr.includes('mermaid-filter')) {
+      throw new Error(
+        `mermaid-filter の実行中にエラーが発生しました。\n` +
+        `Mermaid 図の構文エラーの可能性があります。\n` +
+        `stderr: ${stderr}`
+      );
+    }
+
+    // 汎用的な Pandoc エラー
+    throw new Error(
+      `Pandoc 実行に失敗しました。\n` +
+      `stderr: ${stderr || 'なし'}\n` +
+      `詳細: ${errorDetail}`
+    );
   }
 }
 
 /**
- * .mermaid-config.json を作業ディレクトリに書き出す
+ * Mermaid CLI 用の設定ファイル（.mermaid-config.json）を作業ディレクトリに書き出す。
+ * theme, themeVariables（base テーマ時のみ）、themeCSS のみを含む。
  */
 async function writeMermaidConfig(
   workingDirectory: string,
@@ -107,8 +150,24 @@ async function writeMermaidConfig(
     outputChannel.appendLine(`[Export] .mermaid-config.json を作業ディレクトリに書き出しました: ${configPath}`);
   } catch (err) {
     const errorDetail = err instanceof Error ? err.message : String(err);
-    outputChannel.appendLine(`[Export] 警告: .mermaid-config.json の書き出しに失敗しました。`);
+    const errorCode = (err as { code?: string }).code;
+
+    outputChannel.appendLine(`[Export] エラー: .mermaid-config.json の書き出しに失敗しました。`);
+    outputChannel.appendLine(`  エラーコード: ${errorCode || 'unknown'}`);
     outputChannel.appendLine(`  詳細: ${errorDetail}`);
+
+    // エラーを上位に伝播させる
+    let errorMessage = `Mermaid 設定ファイルの書き出しに失敗しました。\nパス: ${configPath}`;
+
+    if (errorCode === 'EACCES') {
+      errorMessage += '\nディレクトリへの書き込み権限を確認してください。';
+    } else if (errorCode === 'ENOSPC') {
+      errorMessage += '\nディスクの空き容量を確認してください。';
+    }
+
+    errorMessage += `\n詳細: ${errorDetail}`;
+
+    throw new Error(errorMessage);
   }
 }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -75,19 +75,23 @@ function openViewer(): void {
 }
 
 /**
- * 「EPUB にエクスポート」コマンドを実行する（Phase 2）
+ * ドキュメントをエクスポートする共通関数
  */
-async function exportToEpub(): Promise<void> {
+async function exportDocument(target: 'epub' | 'pdf'): Promise<void> {
+  const formatLabel = target.toUpperCase();
+  const extension = target;
+
   const editor = vscode.window.activeTextEditor;
   if (!editor || editor.document.languageId !== 'markdown') {
     vscode.window.showWarningMessage(
-      'Markdown ファイルを開いてから「EPUB にエクスポート」を実行してください。'
+      `Markdown ファイルを開いてから「${formatLabel} にエクスポート」を実行してください。`
     );
     return;
   }
 
   const depsAvailable = await checkExportDependencies(outputChannel);
   if (!depsAvailable) {
+    outputChannel.appendLine(`[Export] ${formatLabel} エクスポートを中止しました: 依存ツールが不足しています`);
     return;
   }
 
@@ -101,11 +105,11 @@ async function exportToEpub(): Promise<void> {
   }
 
   const parsedPath = path.parse(inputPath);
-  const defaultOutputPath = path.join(parsedPath.dir, `${parsedPath.name}.epub`);
+  const defaultOutputPath = path.join(parsedPath.dir, `${parsedPath.name}.${extension}`);
 
   const outputUri = await vscode.window.showSaveDialog({
     defaultUri: vscode.Uri.file(defaultOutputPath),
-    filters: { 'EPUB': ['epub'] },
+    filters: { [formatLabel]: [extension] },
   });
 
   if (!outputUri) {
@@ -118,7 +122,7 @@ async function exportToEpub(): Promise<void> {
     await vscode.window.withProgress(
       {
         location: vscode.ProgressLocation.Notification,
-        title: 'EPUB にエクスポート中...',
+        title: `${formatLabel} にエクスポート中...`,
         cancellable: false,
       },
       async () => {
@@ -126,7 +130,7 @@ async function exportToEpub(): Promise<void> {
           {
             inputPath,
             outputPath: outputUri.fsPath,
-            target: 'epub',
+            target,
             mermaidConfig,
             workingDirectory: workspaceFolder.uri.fsPath,
           },
@@ -134,88 +138,32 @@ async function exportToEpub(): Promise<void> {
         );
       }
     );
-    vscode.window.showInformationMessage(`EPUB エクスポートが完了しました: ${outputUri.fsPath}`);
+    vscode.window.showInformationMessage(`${formatLabel} エクスポートが完了しました: ${outputUri.fsPath}`);
   } catch (err) {
     const errorDetail = err instanceof Error ? err.message : String(err);
-    outputChannel.appendLine(`[Export] EPUB エクスポートに失敗しました。`);
+    outputChannel.appendLine(`[Export] ${formatLabel} エクスポートに失敗しました。`);
     outputChannel.appendLine(`  詳細: ${errorDetail}`);
-    vscode.window.showErrorMessage('EPUB エクスポートに失敗しました。詳細は Output パネルを確認してください。');
+    vscode.window.showErrorMessage(`${formatLabel} エクスポートに失敗しました。詳細は Output パネルを確認してください。`);
   }
 }
 
 /**
- * 「PDF にエクスポート」コマンドを実行する（Phase 2）
+ * 「EPUB にエクスポート」コマンドを実行する
+ */
+async function exportToEpub(): Promise<void> {
+  return exportDocument('epub');
+}
+
+/**
+ * 「PDF にエクスポート」コマンドを実行する
  */
 async function exportToPdf(): Promise<void> {
-  const editor = vscode.window.activeTextEditor;
-  if (!editor || editor.document.languageId !== 'markdown') {
-    vscode.window.showWarningMessage(
-      'Markdown ファイルを開いてから「PDF にエクスポート」を実行してください。'
-    );
-    return;
-  }
-
-  const depsAvailable = await checkExportDependencies(outputChannel);
-  if (!depsAvailable) {
-    return;
-  }
-
-  const doc = editor.document;
-  const inputPath = doc.uri.fsPath;
-  const workspaceFolder = vscode.workspace.workspaceFolders?.[0];
-
-  if (!workspaceFolder) {
-    vscode.window.showErrorMessage('ワークスペースを開いてから実行してください。');
-    return;
-  }
-
-  const parsedPath = path.parse(inputPath);
-  const defaultOutputPath = path.join(parsedPath.dir, `${parsedPath.name}.pdf`);
-
-  const outputUri = await vscode.window.showSaveDialog({
-    defaultUri: vscode.Uri.file(defaultOutputPath),
-    filters: { 'PDF': ['pdf'] },
-  });
-
-  if (!outputUri) {
-    return;
-  }
-
-  const mermaidConfig = loadMermaidConfig(workspaceFolder.uri.fsPath, outputChannel);
-
-  try {
-    await vscode.window.withProgress(
-      {
-        location: vscode.ProgressLocation.Notification,
-        title: 'PDF にエクスポート中...',
-        cancellable: false,
-      },
-      async () => {
-        await runExportPipeline(
-          {
-            inputPath,
-            outputPath: outputUri.fsPath,
-            target: 'pdf',
-            mermaidConfig,
-            workingDirectory: workspaceFolder.uri.fsPath,
-          },
-          outputChannel
-        );
-      }
-    );
-    vscode.window.showInformationMessage(`PDF エクスポートが完了しました: ${outputUri.fsPath}`);
-  } catch (err) {
-    const errorDetail = err instanceof Error ? err.message : String(err);
-    outputChannel.appendLine(`[Export] PDF エクスポートに失敗しました。`);
-    outputChannel.appendLine(`  詳細: ${errorDetail}`);
-    vscode.window.showErrorMessage('PDF エクスポートに失敗しました。詳細は Output パネルを確認してください。');
-  }
+  return exportDocument('pdf');
 }
 
 /**
  * 拡張がアクティベートされたときに呼ばれる。
- * Phase 1: OutputChannel 初期化と Viewer コマンド登録。
- * Phase 2: エクスポートコマンド登録。
+ * OutputChannel 初期化、Viewer コマンド登録、エクスポートコマンド登録。
  * 設定読み込みは openViewer() 内で Viewer を開くたびに実行される。
  */
 export function activate(context: vscode.ExtensionContext): void {
@@ -227,7 +175,7 @@ export function activate(context: vscode.ExtensionContext): void {
     vscode.commands.registerCommand('markdownMermaidViewer.openViewer', openViewer)
   );
 
-  // Phase 2: エクスポートコマンド
+  // エクスポートコマンド
   context.subscriptions.push(
     vscode.commands.registerCommand('markdownMermaidViewer.exportToEpub', exportToEpub)
   );

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -5,8 +5,11 @@
  */
 
 import * as crypto from 'node:crypto';
+import * as path from 'node:path';
 import * as vscode from 'vscode';
 import { getDefaultConfig, loadMermaidConfig } from './configLoader';
+import { runExportPipeline } from './exportPipeline';
+import { checkExportDependencies } from './toolChecker';
 import { getViewerHtml } from './viewerHtml';
 
 /** Webview 用 CSP nonce のバイト数。 */
@@ -72,8 +75,147 @@ function openViewer(): void {
 }
 
 /**
+ * 「EPUB にエクスポート」コマンドを実行する（Phase 2）
+ */
+async function exportToEpub(): Promise<void> {
+  const editor = vscode.window.activeTextEditor;
+  if (!editor || editor.document.languageId !== 'markdown') {
+    vscode.window.showWarningMessage(
+      'Markdown ファイルを開いてから「EPUB にエクスポート」を実行してください。'
+    );
+    return;
+  }
+
+  const depsAvailable = await checkExportDependencies(outputChannel);
+  if (!depsAvailable) {
+    return;
+  }
+
+  const doc = editor.document;
+  const inputPath = doc.uri.fsPath;
+  const workspaceFolder = vscode.workspace.workspaceFolders?.[0];
+
+  if (!workspaceFolder) {
+    vscode.window.showErrorMessage('ワークスペースを開いてから実行してください。');
+    return;
+  }
+
+  const parsedPath = path.parse(inputPath);
+  const defaultOutputPath = path.join(parsedPath.dir, `${parsedPath.name}.epub`);
+
+  const outputUri = await vscode.window.showSaveDialog({
+    defaultUri: vscode.Uri.file(defaultOutputPath),
+    filters: { 'EPUB': ['epub'] },
+  });
+
+  if (!outputUri) {
+    return;
+  }
+
+  const mermaidConfig = loadMermaidConfig(workspaceFolder.uri.fsPath, outputChannel);
+
+  try {
+    await vscode.window.withProgress(
+      {
+        location: vscode.ProgressLocation.Notification,
+        title: 'EPUB にエクスポート中...',
+        cancellable: false,
+      },
+      async () => {
+        await runExportPipeline(
+          {
+            inputPath,
+            outputPath: outputUri.fsPath,
+            target: 'epub',
+            mermaidConfig,
+            workingDirectory: workspaceFolder.uri.fsPath,
+          },
+          outputChannel
+        );
+      }
+    );
+    vscode.window.showInformationMessage(`EPUB エクスポートが完了しました: ${outputUri.fsPath}`);
+  } catch (err) {
+    const errorDetail = err instanceof Error ? err.message : String(err);
+    outputChannel.appendLine(`[Export] EPUB エクスポートに失敗しました。`);
+    outputChannel.appendLine(`  詳細: ${errorDetail}`);
+    vscode.window.showErrorMessage('EPUB エクスポートに失敗しました。詳細は Output パネルを確認してください。');
+  }
+}
+
+/**
+ * 「PDF にエクスポート」コマンドを実行する（Phase 2）
+ */
+async function exportToPdf(): Promise<void> {
+  const editor = vscode.window.activeTextEditor;
+  if (!editor || editor.document.languageId !== 'markdown') {
+    vscode.window.showWarningMessage(
+      'Markdown ファイルを開いてから「PDF にエクスポート」を実行してください。'
+    );
+    return;
+  }
+
+  const depsAvailable = await checkExportDependencies(outputChannel);
+  if (!depsAvailable) {
+    return;
+  }
+
+  const doc = editor.document;
+  const inputPath = doc.uri.fsPath;
+  const workspaceFolder = vscode.workspace.workspaceFolders?.[0];
+
+  if (!workspaceFolder) {
+    vscode.window.showErrorMessage('ワークスペースを開いてから実行してください。');
+    return;
+  }
+
+  const parsedPath = path.parse(inputPath);
+  const defaultOutputPath = path.join(parsedPath.dir, `${parsedPath.name}.pdf`);
+
+  const outputUri = await vscode.window.showSaveDialog({
+    defaultUri: vscode.Uri.file(defaultOutputPath),
+    filters: { 'PDF': ['pdf'] },
+  });
+
+  if (!outputUri) {
+    return;
+  }
+
+  const mermaidConfig = loadMermaidConfig(workspaceFolder.uri.fsPath, outputChannel);
+
+  try {
+    await vscode.window.withProgress(
+      {
+        location: vscode.ProgressLocation.Notification,
+        title: 'PDF にエクスポート中...',
+        cancellable: false,
+      },
+      async () => {
+        await runExportPipeline(
+          {
+            inputPath,
+            outputPath: outputUri.fsPath,
+            target: 'pdf',
+            mermaidConfig,
+            workingDirectory: workspaceFolder.uri.fsPath,
+          },
+          outputChannel
+        );
+      }
+    );
+    vscode.window.showInformationMessage(`PDF エクスポートが完了しました: ${outputUri.fsPath}`);
+  } catch (err) {
+    const errorDetail = err instanceof Error ? err.message : String(err);
+    outputChannel.appendLine(`[Export] PDF エクスポートに失敗しました。`);
+    outputChannel.appendLine(`  詳細: ${errorDetail}`);
+    vscode.window.showErrorMessage('PDF エクスポートに失敗しました。詳細は Output パネルを確認してください。');
+  }
+}
+
+/**
  * 拡張がアクティベートされたときに呼ばれる。
  * Phase 1: OutputChannel 初期化と Viewer コマンド登録。
+ * Phase 2: エクスポートコマンド登録。
  * 設定読み込みは openViewer() 内で Viewer を開くたびに実行される。
  */
 export function activate(context: vscode.ExtensionContext): void {
@@ -83,6 +225,14 @@ export function activate(context: vscode.ExtensionContext): void {
   context.subscriptions.push(outputChannel);
   context.subscriptions.push(
     vscode.commands.registerCommand('markdownMermaidViewer.openViewer', openViewer)
+  );
+
+  // Phase 2: エクスポートコマンド
+  context.subscriptions.push(
+    vscode.commands.registerCommand('markdownMermaidViewer.exportToEpub', exportToEpub)
+  );
+  context.subscriptions.push(
+    vscode.commands.registerCommand('markdownMermaidViewer.exportToPdf', exportToPdf)
   );
 }
 

--- a/src/toolChecker.ts
+++ b/src/toolChecker.ts
@@ -1,0 +1,103 @@
+/**
+ * 外部ツールの存在チェックモジュール
+ * Phase 2: エクスポート機能の依存ツール（mermaid-filter, Pandoc）検出。
+ *
+ * docs/03-implementation/PATTERNS.md および CONVENTIONS.md を参照。
+ */
+import * as childProcess from 'node:child_process';
+import { promisify } from 'node:util';
+import * as vscode from 'vscode';
+
+const execFile = promisify(childProcess.execFile);
+
+/** コマンド存在チェックのタイムアウト（ms）。範囲: 3000-10000 */
+const COMMAND_CHECK_TIMEOUT_MS = 5000;
+
+export interface ToolCheckResult {
+  available: boolean;
+  version?: string;
+  errorMessage?: string;
+}
+
+/**
+ * mermaid-filter の存在と動作をチェックする
+ */
+export async function checkMermaidFilter(
+  outputChannel: vscode.OutputChannel
+): Promise<ToolCheckResult> {
+  try {
+    const { stdout } = await execFile('mermaid-filter', ['--version'], {
+      timeout: COMMAND_CHECK_TIMEOUT_MS
+    });
+    const version = stdout.trim();
+    outputChannel.appendLine(`[ToolCheck] mermaid-filter: ${version}`);
+    return { available: true, version };
+  } catch (err) {
+    const errorDetail = err instanceof Error ? err.message : String(err);
+    outputChannel.appendLine(`[ToolCheck] mermaid-filter が見つかりません。`);
+    outputChannel.appendLine(`  詳細: ${errorDetail}`);
+    return {
+      available: false,
+      errorMessage: 'mermaid-filter が見つかりません。\nインストール方法: npm install -g mermaid-filter'
+    };
+  }
+}
+
+/**
+ * Pandoc の存在と動作をチェックする
+ */
+export async function checkPandoc(
+  outputChannel: vscode.OutputChannel
+): Promise<ToolCheckResult> {
+  try {
+    const { stdout } = await execFile('pandoc', ['--version'], {
+      timeout: COMMAND_CHECK_TIMEOUT_MS
+    });
+    const version = stdout.split('\n')[0]?.trim() || 'unknown';
+    outputChannel.appendLine(`[ToolCheck] Pandoc: ${version}`);
+    return { available: true, version };
+  } catch (err) {
+    const errorDetail = err instanceof Error ? err.message : String(err);
+    outputChannel.appendLine(`[ToolCheck] Pandoc が見つかりません。`);
+    outputChannel.appendLine(`  詳細: ${errorDetail}`);
+    return {
+      available: false,
+      errorMessage: 'Pandoc が見つかりません。\nインストール方法: https://pandoc.org/installing.html'
+    };
+  }
+}
+
+/**
+ * エクスポートに必要なすべてのツールをチェックし、
+ * 不足している場合はユーザーに通知する
+ *
+ * @returns すべてのツールが利用可能な場合は true
+ */
+export async function checkExportDependencies(
+  outputChannel: vscode.OutputChannel
+): Promise<boolean> {
+  const [mermaidFilterResult, pandocResult] = await Promise.all([
+    checkMermaidFilter(outputChannel),
+    checkPandoc(outputChannel)
+  ]);
+
+  const missingTools: string[] = [];
+
+  if (!mermaidFilterResult.available) {
+    missingTools.push(mermaidFilterResult.errorMessage!);
+  }
+
+  if (!pandocResult.available) {
+    missingTools.push(pandocResult.errorMessage!);
+  }
+
+  if (missingTools.length > 0) {
+    const message = `エクスポートに必要なツールが見つかりません:\n\n${missingTools.join('\n\n')}`;
+    vscode.window.showErrorMessage(message);
+    outputChannel.appendLine('[ToolCheck] エクスポート依存ツールのチェック失敗');
+    return false;
+  }
+
+  outputChannel.appendLine('[ToolCheck] すべての依存ツールが利用可能です');
+  return true;
+}

--- a/src/toolChecker.ts
+++ b/src/toolChecker.ts
@@ -1,6 +1,6 @@
 /**
  * 外部ツールの存在チェックモジュール
- * Phase 2: エクスポート機能の依存ツール（mermaid-filter, Pandoc）検出。
+ * エクスポート機能の依存ツール（mermaid-filter, Pandoc）検出。
  *
  * docs/03-implementation/PATTERNS.md および CONVENTIONS.md を参照。
  */
@@ -34,11 +34,25 @@ export async function checkMermaidFilter(
     return { available: true, version };
   } catch (err) {
     const errorDetail = err instanceof Error ? err.message : String(err);
-    outputChannel.appendLine(`[ToolCheck] mermaid-filter が見つかりません。`);
+    const errorCode = (err as { code?: string }).code;
+
+    // ENOENT (コマンドが見つからない) と他のエラーを区別
+    if (errorCode === 'ENOENT') {
+      outputChannel.appendLine(`[ToolCheck] mermaid-filter が見つかりません。`);
+      outputChannel.appendLine(`  詳細: ${errorDetail}`);
+      return {
+        available: false,
+        errorMessage: 'mermaid-filter が見つかりません。\nインストール方法: npm install -g mermaid-filter'
+      };
+    }
+
+    // その他のエラー（タイムアウト、権限エラー等）
+    outputChannel.appendLine(`[ToolCheck] エラー: mermaid-filter の実行中に予期しないエラーが発生しました。`);
+    outputChannel.appendLine(`  エラーコード: ${errorCode || 'unknown'}`);
     outputChannel.appendLine(`  詳細: ${errorDetail}`);
     return {
       available: false,
-      errorMessage: 'mermaid-filter が見つかりません。\nインストール方法: npm install -g mermaid-filter'
+      errorMessage: `mermaid-filter の実行中にエラーが発生しました: ${errorDetail}`
     };
   }
 }
@@ -58,11 +72,25 @@ export async function checkPandoc(
     return { available: true, version };
   } catch (err) {
     const errorDetail = err instanceof Error ? err.message : String(err);
-    outputChannel.appendLine(`[ToolCheck] Pandoc が見つかりません。`);
+    const errorCode = (err as { code?: string }).code;
+
+    // ENOENT (コマンドが見つからない) と他のエラーを区別
+    if (errorCode === 'ENOENT') {
+      outputChannel.appendLine(`[ToolCheck] Pandoc が見つかりません。`);
+      outputChannel.appendLine(`  詳細: ${errorDetail}`);
+      return {
+        available: false,
+        errorMessage: 'Pandoc が見つかりません。\nインストール方法: https://pandoc.org/installing.html'
+      };
+    }
+
+    // その他のエラー（タイムアウト、権限エラー等）
+    outputChannel.appendLine(`[ToolCheck] エラー: Pandoc の実行中に予期しないエラーが発生しました。`);
+    outputChannel.appendLine(`  エラーコード: ${errorCode || 'unknown'}`);
     outputChannel.appendLine(`  詳細: ${errorDetail}`);
     return {
       available: false,
-      errorMessage: 'Pandoc が見つかりません。\nインストール方法: https://pandoc.org/installing.html'
+      errorMessage: `Pandoc の実行中にエラーが発生しました: ${errorDetail}`
     };
   }
 }
@@ -84,11 +112,21 @@ export async function checkExportDependencies(
   const missingTools: string[] = [];
 
   if (!mermaidFilterResult.available) {
-    missingTools.push(mermaidFilterResult.errorMessage!);
+    if (!mermaidFilterResult.errorMessage) {
+      outputChannel.appendLine('[ToolCheck] エラー: mermaid-filter チェックが失敗しましたが、エラーメッセージがありません');
+      missingTools.push('mermaid-filter のチェックに失敗しました（理由不明）');
+    } else {
+      missingTools.push(mermaidFilterResult.errorMessage);
+    }
   }
 
   if (!pandocResult.available) {
-    missingTools.push(pandocResult.errorMessage!);
+    if (!pandocResult.errorMessage) {
+      outputChannel.appendLine('[ToolCheck] エラー: Pandoc チェックが失敗しましたが、エラーメッセージがありません');
+      missingTools.push('Pandoc のチェックに失敗しました（理由不明）');
+    } else {
+      missingTools.push(pandocResult.errorMessage);
+    }
   }
 
   if (missingTools.length > 0) {

--- a/src/toolChecker.ts
+++ b/src/toolChecker.ts
@@ -35,11 +35,15 @@ export async function checkMermaidFilter(
   } catch (err) {
     const errorDetail = err instanceof Error ? err.message : String(err);
     const errorCode = (err as { code?: string }).code;
+    const stderr = (err as { stderr?: string }).stderr;
 
     // ENOENT (コマンドが見つからない) と他のエラーを区別
     if (errorCode === 'ENOENT') {
       outputChannel.appendLine(`[ToolCheck] mermaid-filter が見つかりません。`);
       outputChannel.appendLine(`  詳細: ${errorDetail}`);
+      if (stderr) {
+        outputChannel.appendLine(`  stderr: ${stderr}`);
+      }
       return {
         available: false,
         errorMessage: 'mermaid-filter が見つかりません。\nインストール方法: npm install -g mermaid-filter'
@@ -50,6 +54,9 @@ export async function checkMermaidFilter(
     outputChannel.appendLine(`[ToolCheck] エラー: mermaid-filter の実行中に予期しないエラーが発生しました。`);
     outputChannel.appendLine(`  エラーコード: ${errorCode || 'unknown'}`);
     outputChannel.appendLine(`  詳細: ${errorDetail}`);
+    if (stderr) {
+      outputChannel.appendLine(`  stderr: ${stderr}`);
+    }
     return {
       available: false,
       errorMessage: `mermaid-filter の実行中にエラーが発生しました: ${errorDetail}`
@@ -73,11 +80,15 @@ export async function checkPandoc(
   } catch (err) {
     const errorDetail = err instanceof Error ? err.message : String(err);
     const errorCode = (err as { code?: string }).code;
+    const stderr = (err as { stderr?: string }).stderr;
 
     // ENOENT (コマンドが見つからない) と他のエラーを区別
     if (errorCode === 'ENOENT') {
       outputChannel.appendLine(`[ToolCheck] Pandoc が見つかりません。`);
       outputChannel.appendLine(`  詳細: ${errorDetail}`);
+      if (stderr) {
+        outputChannel.appendLine(`  stderr: ${stderr}`);
+      }
       return {
         available: false,
         errorMessage: 'Pandoc が見つかりません。\nインストール方法: https://pandoc.org/installing.html'
@@ -88,6 +99,9 @@ export async function checkPandoc(
     outputChannel.appendLine(`[ToolCheck] エラー: Pandoc の実行中に予期しないエラーが発生しました。`);
     outputChannel.appendLine(`  エラーコード: ${errorCode || 'unknown'}`);
     outputChannel.appendLine(`  詳細: ${errorDetail}`);
+    if (stderr) {
+      outputChannel.appendLine(`  stderr: ${stderr}`);
+    }
     return {
       available: false,
       errorMessage: `Pandoc の実行中にエラーが発生しました: ${errorDetail}`

--- a/src/types.ts
+++ b/src/types.ts
@@ -26,6 +26,26 @@ export interface MermaidThemeVariables {
 }
 
 /**
+ * エクスポート設定（Phase 2）
+ */
+export interface ExportOptions {
+  /** 解像度（DPI）。最小 72、最大 600、デフォルト 300 */
+  dpi?: number;
+  /** 図の最大幅（px）。最小 400、最大 2000、デフォルト 800 */
+  width?: number;
+  /** EPUB エクスポート時の設定 */
+  epub?: {
+    /** 画像形式。デフォルト png */
+    format?: 'png' | 'svg';
+  };
+  /** PDF エクスポート時の設定 */
+  pdf?: {
+    /** 画像形式。デフォルト svg */
+    format?: 'png' | 'svg';
+  };
+}
+
+/**
  * .mermaid-config.json の設定オブジェクト。
  * Mermaid.initialize() に渡す設定と対応。
  */
@@ -36,4 +56,6 @@ export interface MermaidConfig {
   startOnLoad?: boolean;
   securityLevel?: 'strict' | 'loose' | 'antiscript' | 'sandbox';
   logLevel?: 'fatal' | 'error' | 'warn' | 'info' | 'debug' | 'trace' | 0 | 1 | 2 | 3 | 4 | 5;
+  /** Phase 2: エクスポート設定 */
+  export?: ExportOptions;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -26,22 +26,22 @@ export interface MermaidThemeVariables {
 }
 
 /**
- * エクスポート設定（Phase 2）
+ * エクスポート設定
  */
 export interface ExportOptions {
   /** 解像度（DPI）。最小 72、最大 600、デフォルト 300 */
-  dpi?: number;
+  readonly dpi?: number;
   /** 図の最大幅（px）。最小 400、最大 2000、デフォルト 800 */
-  width?: number;
+  readonly width?: number;
   /** EPUB エクスポート時の設定 */
-  epub?: {
+  readonly epub?: {
     /** 画像形式。デフォルト png */
-    format?: 'png' | 'svg';
+    readonly format?: 'png' | 'svg';
   };
   /** PDF エクスポート時の設定 */
-  pdf?: {
+  readonly pdf?: {
     /** 画像形式。デフォルト svg */
-    format?: 'png' | 'svg';
+    readonly format?: 'png' | 'svg';
   };
 }
 
@@ -56,6 +56,6 @@ export interface MermaidConfig {
   startOnLoad?: boolean;
   securityLevel?: 'strict' | 'loose' | 'antiscript' | 'sandbox';
   logLevel?: 'fatal' | 'error' | 'warn' | 'info' | 'debug' | 'trace' | 0 | 1 | 2 | 3 | 4 | 5;
-  /** Phase 2: エクスポート設定 */
+  /** エクスポート設定 */
   export?: ExportOptions;
 }

--- a/test-export.md
+++ b/test-export.md
@@ -1,0 +1,53 @@
+# Mermaid エクスポートテスト
+
+このドキュメントは Phase 2 のエクスポート機能をテストするためのサンプルです。
+
+## フローチャート
+
+```mermaid
+graph TD
+    A[開始] --> B{条件分岐}
+    B -->|Yes| C[処理A]
+    B -->|No| D[処理B]
+    C --> E[終了]
+    D --> E
+```
+
+## シーケンス図
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant System
+    participant Database
+
+    User->>System: リクエスト送信
+    System->>Database: データ取得
+    Database-->>System: データ返却
+    System-->>User: レスポンス返却
+```
+
+## クラス図
+
+```mermaid
+classDiagram
+    class Animal {
+        +String name
+        +int age
+        +makeSound()
+    }
+    class Dog {
+        +String breed
+        +bark()
+    }
+    class Cat {
+        +String color
+        +meow()
+    }
+    Animal <|-- Dog
+    Animal <|-- Cat
+```
+
+## まとめ
+
+このドキュメントには 3 つの Mermaid 図が含まれています。EPUB/PDF エクスポート時に、これらが正しく画像として埋め込まれることを確認します。


### PR DESCRIPTION
## 概要

Issue #18, #17, #16, #15 に対応し、Phase 2 の EPUB/PDF エクスポート機能を実装しました。

Closes #18
Closes #17
Closes #16
Closes #15

## 実装内容

### 新規機能

1. **依存ツール検出（#18）**
   - mermaid-filter と Pandoc の存在チェック機能
   - 未インストール時のユーザー向け案内メッセージ
   - インストール方法の提示

2. **設定スキーマ拡張（#17）**
   - `.mermaid-config.json` に `export` フィールドを追加
   - DPI（解像度）、width（図の幅）、format（画像形式）を設定可能に
   - デフォルト値: DPI=300, width=800px

3. **形式出し分けロジック（#16）**
   - EPUB: デフォルト PNG（Kindle 互換性優先）
   - PDF: デフォルト SVG（高品質ベクター形式）
   - 設定でオーバーライド可能

4. **エクスポート基盤（#15）**
   - Pandoc + mermaid-filter による EPUB/PDF 変換パイプライン
   - 「EPUB にエクスポート」「PDF にエクスポート」コマンド
   - .mermaid-config.json のテーマ設定を反映

### 新規ファイル

- `src/toolChecker.ts`: 依存ツール（mermaid-filter, Pandoc）の存在チェック
- `src/exportFormatResolver.ts`: エクスポート形式（画像形式、DPI、幅）の解決ロジック
- `src/exportPipeline.ts`: Pandoc 実行パイプライン

### 変更ファイル

- `src/types.ts`: ExportOptions 型を追加
- `src/constants.ts`: エクスポート関連定数（DPI, width, format のデフォルト値・範囲）を追加
- `src/configLoader.ts`: export フィールドの検証ロジックを追加
- `src/extension.ts`: エクスポートコマンド（exportToEpub, exportToPdf）を追加
- `package.json`: コマンド定義と activationEvents を追加

## テスト計画

### 単体テスト（手動）

- [ ] mermaid-filter 未インストール時に適切なエラーメッセージが表示される
- [ ] Pandoc 未インストール時に適切なエラーメッセージが表示される
- [ ] .mermaid-config.json の export フィールドが正しく読み込まれる
- [ ] 無効な DPI/width 値が警告される

### 統合テスト（手動）

- [ ] EPUB エクスポートコマンドが正常に動作する
- [ ] PDF エクスポートコマンドが正常に動作する
- [ ] Mermaid 図が画像として埋め込まれている
- [ ] .mermaid-config.json のテーマが反映されている

### 動作確認環境

- Node.js 22.x
- VS Code 1.100+
- mermaid-filter 最新版
- Pandoc 最新版

## チェックリスト

- [x] 型チェック通過（`npm run check-types`）
- [x] ビルド成功（`npm run compile`）
- [x] DRY 原則遵守（重複コード・import・マジックナンバーなし）
- [x] エラーハンドリング統一（OutputChannel + vscode.window.showErrorMessage）
- [x] Import 整理（stdlib → third-party → local）
- [x] ドキュメント追加（JSDoc コメント）
- [ ] 手動テスト実施

## 備考

- Phase 2 の全 Issue（#15, #16, #17, #18）を一括実装
- Phase 1 の設計思想（レイヤードアーキテクチャ、設定優先順位）を踏襲
- 次フェーズ（Phase 3）ではパフォーマンス最適化と KDP 向け機能を実装予定